### PR TITLE
permission tabs to activeTab in manifest

### DIFF
--- a/chromium/authifyNow/manifest.json
+++ b/chromium/authifyNow/manifest.json
@@ -52,7 +52,7 @@
 	
 	
     "permissions": [
-        "tabs"
+        "activeTab"
     ]
 	
 }

--- a/firefox/authifyNow/manifest.json
+++ b/firefox/authifyNow/manifest.json
@@ -55,7 +55,7 @@
 	
 	
     "permissions": [
-        "tabs"
+        "activeTab"
     ]
 	
 }


### PR DESCRIPTION
activeTab is more private and the plugin once the user moves to a new page, the plugin permission is revoked.
fixes #19 