### PR TITLE
remove content script from manifest

### DIFF
--- a/chromium/authifyNow/manifest.json
+++ b/chromium/authifyNow/manifest.json
@@ -20,16 +20,7 @@
             "images/icon32.png"
 		
     },
-	"content_scripts": [
-		{
-			"matches": [
-				"<all_urls>"
-			],
-			"js": [
-				"resources/purify.min.js"
-			]
-		}
-	],
+	
 	"commands":{
 		"_execute_action":{
 			"suggested_key":{

--- a/firefox/authifyNow/manifest.json
+++ b/firefox/authifyNow/manifest.json
@@ -30,16 +30,7 @@
 		}
 		
 	},
-	"content_scripts": [
-		{
-			"matches": [
-				"<all_urls>"
-			],
-			"js": [
-				"resources/purify.min.js"
-			]
-		}
-	],
+	
 
 	
 	"options_ui": {


### PR DESCRIPTION
Content script is not necessary for the plugin to work. Using content script with the existing setting also asks for permission to access all URL's from the user, which is unnecessary. Fixes #18